### PR TITLE
fix: Error in pathfinding causing sub-optimal paths

### DIFF
--- a/Source/AeonixNavigation/Private/Data/AeonixOctreeData.cpp
+++ b/Source/AeonixNavigation/Private/Data/AeonixOctreeData.cpp
@@ -206,7 +206,7 @@ void FAeonixOctreeData::GetNeighbours(const AeonixLink& aLink, TArray<AeonixLink
 				for (const nodeindex_t& leafIndex : AeonixStatics::dirLeafChildOffsets[i])
 				{
 					// Each of the childnodes
-					AeonixLink link = neighbour.FirstChild;
+					AeonixLink link = thisNode.FirstChild;
 					const AeonixLeafNode& leafNode = GetLeafNode(link.NodeIndex);
 					link.SubnodeIndex = leafIndex;
 


### PR DESCRIPTION
Pathfinding bug that would cause strange paths going from high level nodes to leaf level.

closes #20 