### PR TITLE
fix: Unsafe references to unstable container

### DIFF
--- a/Source/AeonixNavigation/Public/Subsystem/AeonixSubsystem.h
+++ b/Source/AeonixNavigation/Public/Subsystem/AeonixSubsystem.h
@@ -110,6 +110,6 @@ private:
 	FOnRegistrationChanged OnRegistrationChanged;
 
 private:
-	TArray<FAeonixPathFindRequest> PathRequests;
+	TArray<TUniquePtr<FAeonixPathFindRequest>> PathRequests;
 };
 


### PR DESCRIPTION
Storing references to elements in a vector is a terrible idea. I've even written a blog post about it, yet I still do it! Fixed.